### PR TITLE
Fix artifact PURLs

### DIFF
--- a/plugins/scanners/dos/src/main/kotlin/DOSUtils.kt
+++ b/plugins/scanners/dos/src/main/kotlin/DOSUtils.kt
@@ -24,7 +24,7 @@ internal fun Collection<Package>.getDosPurls(provenance: Provenance = UnknownPro
             map { it.id.toPurl(extras.qualifiers, it.vcsProcessed.path) }
         }
 
-        else -> map { it.purl }
+        else -> map { it.id.toPurl(extras) }
     }
 }
 


### PR DESCRIPTION
This is a fixup for d3b6475 which started to treat `RepositioryProvenance` differently from other `KnownProvenance`.

Note that `UnknownProvenance` does not need to be treated separately as the `toPurlExtras()` is able to handle it.