### PR TITLE
chore(dos): Relicense all DOS code from `MIT` to `Apache-2.0`

### DIFF
--- a/clients/dos/src/main/kotlin/DOSRepository.kt
+++ b/clients/dos/src/main/kotlin/DOSRepository.kt
@@ -1,7 +1,20 @@
 /*
- * SPDX-FileCopyrightText: 2023 Double Open Oy <support@doubleopen.org>
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
  *
- * SPDX-License-Identifier: MIT
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
  */
 
 package org.ossreviewtoolkit.clients.dos

--- a/clients/dos/src/main/kotlin/DOSService.kt
+++ b/clients/dos/src/main/kotlin/DOSService.kt
@@ -1,7 +1,20 @@
 /*
- * SPDX-FileCopyrightText: 2023 Double Open Oy <support@doubleopen.org>
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
  *
- * SPDX-License-Identifier: MIT
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
  */
 
 package org.ossreviewtoolkit.clients.dos

--- a/plugins/package-configuration-providers/dos/src/main/kotlin/DosPackageConfigurationProvider.kt
+++ b/plugins/package-configuration-providers/dos/src/main/kotlin/DosPackageConfigurationProvider.kt
@@ -1,8 +1,22 @@
 /*
- * SPDX-FileCopyrightText: 2023 Double Open Oy
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
  *
- * SPDX-License-Identifier: MIT
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
  */
+
 package org.ossreviewtoolkit.plugins.packageconfigurationproviders.dos
 
 import kotlinx.coroutines.runBlocking

--- a/plugins/scanners/dos/src/main/kotlin/DOS.kt
+++ b/plugins/scanners/dos/src/main/kotlin/DOS.kt
@@ -1,7 +1,20 @@
 /*
- * SPDX-FileCopyrightText: 2023 Double Open Oy <support@doubleopen.org>
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
  *
- * SPDX-License-Identifier: MIT
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
  */
 
 package org.ossreviewtoolkit.plugins.scanners.dos

--- a/plugins/scanners/dos/src/main/kotlin/DOSConfig.kt
+++ b/plugins/scanners/dos/src/main/kotlin/DOSConfig.kt
@@ -1,7 +1,20 @@
 /*
- * SPDX-FileCopyrightText: 2023 Double Open Oy <support@doubleopen.org>
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
  *
- * SPDX-License-Identifier: MIT
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
  */
 
 package org.ossreviewtoolkit.plugins.scanners.dos

--- a/plugins/scanners/dos/src/main/kotlin/DOSResultParser.kt
+++ b/plugins/scanners/dos/src/main/kotlin/DOSResultParser.kt
@@ -1,7 +1,20 @@
 /*
- * SPDX-FileCopyrightText: 2023 Double Open Oy <support@doubleopen.org>
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
  *
- * SPDX-License-Identifier: MIT
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
  */
 
 /**

--- a/plugins/scanners/dos/src/main/kotlin/DOSUtils.kt
+++ b/plugins/scanners/dos/src/main/kotlin/DOSUtils.kt
@@ -1,7 +1,20 @@
 /*
- * SPDX-FileCopyrightText: 2023 Double Open Oy <support@doubleopen.org>
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
  *
- * SPDX-License-Identifier: MIT
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
  */
 
 package org.ossreviewtoolkit.plugins.scanners.dos

--- a/plugins/scanners/dos/src/test/kotlin/DOSTest.kt
+++ b/plugins/scanners/dos/src/test/kotlin/DOSTest.kt
@@ -1,7 +1,20 @@
 /*
- * SPDX-FileCopyrightText: 2023 Double Open Oy <support@doubleopen.org>
+ * Copyright (C) 2023 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
  *
- * SPDX-License-Identifier: MIT
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
  */
 
 package org.ossreviewtoolkit.plugins.scanners.dos


### PR DESCRIPTION
This is to align with ORT core / server. Note that Double Open is already listed as part of [1].

[1]: https://github.com/oss-review-toolkit/ort/blob/1765a15572c3b02ab7c75e21cfa661109a19aeac/NOTICE#L17